### PR TITLE
Add "missing-colour" argument for handling missing blocks

### DIFF
--- a/fastanvil/src/rendered_palette.rs
+++ b/fastanvil/src/rendered_palette.rs
@@ -13,6 +13,7 @@ pub struct RenderedPalette {
     pub blockstates: std::collections::HashMap<String, Rgba>,
     pub grass: image::RgbaImage,
     pub foliage: image::RgbaImage,
+    pub missing_colour: [u8; 4],
 }
 
 impl RenderedPalette {
@@ -63,8 +64,6 @@ impl RenderedPalette {
 
 impl Palette for RenderedPalette {
     fn pick(&self, block: &Block, biome: Option<Biome>) -> Rgba {
-        let missing_colour = [255, 0, 255, 255];
-
         // A bunch of blocks in the game seem to be special cased outside of the
         // blockstate/model mechanism. For example leaves get coloured based on
         // the tree type and the biome type, but this is not encoded in the
@@ -125,7 +124,7 @@ impl Palette for RenderedPalette {
             Some(c) => *c,
             None => {
                 debug!("could not draw {}", block.encoded_description());
-                missing_colour
+                self.missing_colour
             }
         }
     }
@@ -202,5 +201,6 @@ pub fn load_rendered_palette(
         blockstates: blockstates?,
         grass: grass?,
         foliage: foliage?,
+        missing_colour: [255, 0, 255, 255],
     })
 }

--- a/tools/src/bin/anvil.rs
+++ b/tools/src/bin/anvil.rs
@@ -18,6 +18,15 @@ fn parse_coord(coord: &str) -> Option<(isize, isize)> {
     Some((x, z))
 }
 
+fn parse_colour(colour: &str) -> Option<[u8; 4]> {
+    let mut s = colour.split(',');
+    let r: u8 = s.next()?.parse().ok()?;
+    let g: u8 = s.next()?.parse().ok()?;
+    let b: u8 = s.next()?.parse().ok()?;
+    let a: u8 = s.next()?.parse().ok()?;
+    Some([r, g, b, a])
+}
+
 fn auto_size(coords: &[(RCoord, RCoord)]) -> Option<Rectangle> {
     if coords.is_empty() {
         return None;
@@ -57,7 +66,7 @@ struct Rectangle {
     zmax: RCoord,
 }
 
-fn get_palette(path: Option<&str>) -> Result<RenderedPalette> {
+fn get_palette(path: Option<&str>, missing_colour: [u8; 4]) -> Result<RenderedPalette> {
     let path = match path {
         Some(path) => Path::new(path),
         None => panic!("no palette"),
@@ -103,6 +112,7 @@ fn get_palette(path: Option<&str>) -> Result<RenderedPalette> {
         blockstates: blockstates?,
         grass: grass?,
         foliage: foliage?,
+        missing_colour: missing_colour,
     };
 
     Ok(p)
@@ -141,7 +151,11 @@ fn render(args: &ArgMatches) -> Result<()> {
 
     let region_len: usize = 32 * 16;
 
-    let pal = get_palette(args.value_of("palette"))?;
+    let missing_colour = match parse_colour(args.value_of("missing-colour").unwrap()) {
+        Some(colour) => colour,
+        None => panic!("invalid missing colour, please use format \"r,g,b,a\""),
+    };
+    let pal = get_palette(args.value_of("palette"), missing_colour)?;
 
     let region_maps: Vec<_> = coords
         .into_par_iter()
@@ -242,7 +256,11 @@ fn tiles(args: &ArgMatches) -> Result<()> {
 
     let region_len: usize = 32 * 16;
 
-    let pal = get_palette(args.value_of("palette"))?;
+    let missing_colour = match parse_colour(args.value_of("missing-colour").unwrap()) {
+        Some(colour) => colour,
+        None => panic!("invalid missing colour, please use format \"r,g,b,a\""),
+    };
+    let pal = get_palette(args.value_of("palette"), missing_colour)?;
 
     let regions_processed = coords
         .into_par_iter()
@@ -383,6 +401,14 @@ fn main() -> Result<()> {
                         .long("palette")
                         .takes_value(true)
                         .required(false),
+                )
+                .arg(
+                    Arg::with_name("missing-colour")
+                        .long("missing-colour")
+                        .takes_value(true)
+                        .required(false)
+                        .help("Use the given color for missing blocks. If alpha is less than 255, move down until a non-missing block is found. Example: 0,0,0,0")
+                        .default_value("255,0,255,255"),
                 )
                 .arg(
                     Arg::with_name("calculate-heights")

--- a/tools/src/bin/anvil.rs
+++ b/tools/src/bin/anvil.rs
@@ -112,7 +112,7 @@ fn get_palette(path: Option<&str>, missing_colour: [u8; 4]) -> Result<RenderedPa
         blockstates: blockstates?,
         grass: grass?,
         foliage: foliage?,
-        missing_colour: missing_colour,
+        missing_colour,
     };
 
     Ok(p)


### PR DESCRIPTION
Changes in `fastanvil/src/rendered_palette.rs`:
- Added `pub missing_colour: [u8; 4]` field to the `RenderedPalette` struct to store the missing block color.

Changes in `tools/src/bin/anvil.rs`:
- Updated the `get_palette` function to accept the `missing_colour` as a parameter.
- Added the "missing-colour" argument to the `main` function using `Arg::with_name("missing-colour")`.
  - The argument is optional and has a default value of "255,0,255,255".
  - It accepts a color value in the format "r,g,b,a".
  - The help message explains the usage: "Use the given color for missing blocks. If alpha is less than 255, move down until a non-missing block is found. Example: 0,0,0,0".